### PR TITLE
Uppercase Git

### DIFF
--- a/_posts/2014-11-02-git-ninja-class-in-amsterdam.md
+++ b/_posts/2014-11-02-git-ninja-class-in-amsterdam.md
@@ -10,7 +10,7 @@ categories:
 author: pascal_precht
 ---
 
-Today we are very happy to announce that **we will bring our Git Ninja Class to Amsterdam** in the Netherlands! Join us for another exciting two-day workshop experience about the true power of the git version control system.
+Today we are very happy to announce that **we will bring our Git Ninja Class to Amsterdam** in the Netherlands! Join us for another exciting two-day workshop experience about the true power of the Git version control system.
 
 The workshop takes place at the 15th and 16th January 2015 in the wonderful rooms of [De Voorhoede](http://voorhoede.nl/).
 


### PR DESCRIPTION
It's [debatable](https://github.com/git/git/commit/e83c5163316f89bfbde7d9ab23ca2e25604af290#diff-c47c7c7383225ab55ff591cb59c41e6bR1) whether it's spelled Git, GIT, or "git", we default to Git. But yeah, ultimately I'm just being pedantic here... :trollface:
