### PR TITLE
Reference fixed Plunk using Angular 2 beta

### DIFF
--- a/_posts/2015-04-9-developing-a-tabs-component-in-angular-2.md
+++ b/_posts/2015-04-9-developing-a-tabs-component-in-angular-2.md
@@ -358,6 +358,6 @@ We can take totally different approach how to implement our simple tabs ( which 
 leveraging special Angular 2 `@ContentChildren` property decorator with `QueryList` type and `AfterContentInit` life cycle interface.
 Those are more advanced concepts, which we will cover in future articles.
 
-If you're just curious how it looks like, you can find live demo in [this plunk](http://plnkr.co/edit/Y5VVAATuKJXhMz69SxfF?p=preview)
+If you're just curious how it looks like, you can find live demo in [this plunk](https://plnkr.co/edit/afhLA8wHw9LRnzwwTT3M?p=preview)
 
 Stay tuned!


### PR DESCRIPTION
This commit references a forked plunk that upgrades the tab component example (using ContentChildren) to Angular 2 beta.

Btw, do you mind if I write a follow-up of your article on developing a tab component [on my blog](http://juristr.com/blog), but explaining the approach using `@ContentChildren`? 

I'd obviously reference to this article here. Let me know :smile: 