### PR TITLE
corrected the syntax for optional transclusion slots

### DIFF
--- a/_posts/2015-11-16-multiple-transclusion-and-named-slots.md
+++ b/_posts/2015-11-16-multiple-transclusion-and-named-slots.md
@@ -161,12 +161,12 @@ Isn't that cool? Here's the code in action:
 
 <iframe src="http://embed.plnkr.co/R6s7EYUOJ1NlsDqpt0gP/"></iframe>
 
-We can even make transclusion slots optional by prefixing the slot name with a `?` like this:
+We can even make transclusion slots optional by prefixing the element tag name with a `?` like this:
 
 {% highlight html %}
 {% raw %}
 transclude: {
-  '?summarySlot': 'span'
+  'summarySlot': '?span'
 }
 {% endraw %}
 {% endhighlight %}


### PR DESCRIPTION
There's an mistake in the syntax, which results in the following error:

`Error: [$compile:reqslot] Required transclusion slot '?summarySlot' was not filled.`
[Plnkr](https://plnkr.co/edit/pXygLNn2VZbxmC1pqRYr)

And fixed [Plnkr](https://plnkr.co/edit/8xkOEbwMw4oZQYGyjVmH)