### PR TITLE
fix: typo for NG_VALUE_ACCESSOR in custom form control

### DIFF
--- a/_posts/2016-07-27-custom-form-controls-in-angular-2.md
+++ b/_posts/2016-07-27-custom-form-controls-in-angular-2.md
@@ -301,7 +301,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
   ...
   providers: [
     { 
-      provide: NG_VALUE_ACCESSORS,
+      provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => CounterInputComponent),
       multi: true
     }


### PR DESCRIPTION
Remove 'S' in 'NG_VALIE_ACCESSOR**S**'.