### PR TITLE
fix: typo for registerOnTouched method

### DIFF
--- a/_posts/2016-07-27-custom-form-controls-in-angular-2.md
+++ b/_posts/2016-07-27-custom-form-controls-in-angular-2.md
@@ -222,7 +222,7 @@ writeValue(value: any) {
 {% endraw %}
 {% endhighlight %}
 
-Now, it only overrides the default when there's an actual value written to the control. Next, we implement `registerOnChange()` and `registerOnTouch()`. `registerOnChange()` has access to a function that informs the outside world about changes. Here's where we can do special work, whenever we propagate the change, if we wanted to. `registerOnTouch()` registers a callback that is excuted whenever a form contorl is "touched". E.g. when an input element blurs, it fire the touch event. We don't want to do anything at this event, so we can implement the interface with an empty function.
+Now, it only overrides the default when there's an actual value written to the control. Next, we implement `registerOnChange()` and `registerOnTouched()`. `registerOnChange()` has access to a function that informs the outside world about changes. Here's where we can do special work, whenever we propagate the change, if we wanted to. `registerOnTouched()` registers a callback that is excuted whenever a form control is "touched". E.g. when an input element blurs, it fire the touch event. We don't want to do anything at this event, so we can implement the interface with an empty function.
 
 {% highlight js %}
 {% raw %}
@@ -235,7 +235,7 @@ class CounterInputComponent implements ControlValueAccessor {
     this.propagateChange = fn;
   }
 
-  registerOnTouch() {}
+  registerOnTouched() {}
 }
 {% endraw %}
 {% endhighlight %}


### PR DESCRIPTION
Hi! The method is defined as `registerOnTouched` in the [interface](https://github.com/angular/angular/blob/6fd5bc075d70879c487c0188f6cd5b148e72a4dd/modules/%40angular/forms/src/directives/control_value_accessor.ts#L35). Cheers.