### PR TITLE
fix: add forwardRef import

### DIFF
--- a/_posts/2016-07-27-custom-form-controls-in-angular-2.md
+++ b/_posts/2016-07-27-custom-form-controls-in-angular-2.md
@@ -308,6 +308,7 @@ Let's do that right away:
 
 {% highlight js %}
 {% raw %}
+import { Component, Input, forwardRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({


### PR DESCRIPTION
Hi! `forwardRef`is used throughout the article but not imported. I think writing the import the first time makes it easy for newcomers. Cheers.