### PR TITLE
fix: example at the end injects MockBackend

### DIFF
--- a/_posts/2016-11-28-testing-services-with-http-in-angular-2.md
+++ b/_posts/2016-11-28-testing-services-with-http-in-angular-2.md
@@ -379,7 +379,7 @@ describe('VideoService', () => {
   describe('getVideos()', () => {
 
     it('should return an Observable<Array<Video>>',
-        inject([VideoService, MockBackend], (videoService, mockBackend) => {
+        inject([VideoService, XHRBackend], (videoService, mockBackend) => {
 
         const mockResponse = {
           data: [


### PR DESCRIPTION
The example at the end injects MockBackend, which leads to error “Error: No provider for MockBackend!” Changed it to XHRBackend