### PR TITLE
added note about the shareReplay operator

### DIFF
--- a/_posts/2016-06-16-cold-vs-hot-observables.md
+++ b/_posts/2016-06-16-cold-vs-hot-observables.md
@@ -385,9 +385,12 @@ this.contacts = http.get('contacts.json')
 
 **Note: When using multiple async pipes on streams with default values, the `.share()` operator might cause problems:**
 
-The `share()`will publish the first value of the stream on the first subscription. The first async pipe will trigger that subscription and get that initial value. The second async pipe however will subscribe after that value has already been emitted and therefore miss that value.
+The `share()` will publish the first value of the stream on the first subscription. The first async pipe will trigger that subscription and get that initial value. The second async pipe however will subscribe after that value has already been emitted and therefore miss that value.
 
-The solution for this problem is the `.shareReplay()` operator, which will keep track of the previous values of the stream. That way all the async pipes will get the last value. Just like the `share()` operator is a shortcut for `publish().refCount()`, the `shareReplay()` operator is a shortcut for `publishReplay().refCount()`. We can see the difference between `share()` and `shareReplay()` in [the following plunk](http://plnkr.co/edit/q9xfvjzHauRBsA8o4nob?p=preview).
+The solution for this problem is the `.shareReplay(1)` operator, which will keep track of the previous value of the stream. That way all the async pipes will get the last value. Just like the `share()` operator is a shortcut for `publish().refCount()`, the `shareReplay(1)` operator is a shortcut for `publishReplay(1).refCount()`. We can see the difference between `share()` and `shareReplay(1)` in [the following plunk](http://plnkr.co/edit/q9xfvjzHauRBsA8o4nob?p=preview).
+We should always pass `1` as the parameter value to the shareReplay function. Otherwise RxJS will keep track of all the values of that observable, when we only need the last one.
 
+It's important to note that this problem will only occur when using streams with initial values. 
+The share operator would not pose problems with regular http requests for instance.
 
 Whew! We came a long way. We hope this gives you a clearer picture of what the term hot vs cold actually means when it comes to Observables.

--- a/_posts/2016-06-16-cold-vs-hot-observables.md
+++ b/_posts/2016-06-16-cold-vs-hot-observables.md
@@ -383,5 +383,11 @@ this.contacts = http.get('contacts.json')
 {% endraw %}
 {% endhighlight %}
 
+**Note: When using multiple async pipes on streams with default values, the `.share()` operator might cause problems:**
+
+The `share()`will publish the first value of the stream on the first subscription. The first async pipe will trigger that subscription and get that initial value. The second async pipe however will subscribe after that value has already been emitted and therefore miss that value.
+
+The solution for this problem is the `.shareReplay()` operator, which will keep track of the previous values of the stream. That way all the async pipes will get the last value. Just like the `share()` operator is a shortcut for `publish().refCount()`, the `shareReplay()` operator is a shortcut for `publishReplay().refCount()`. We can see the difference between `share()` and `shareReplay()` in [the following plunk](http://plnkr.co/edit/q9xfvjzHauRBsA8o4nob?p=preview).
+
 
 Whew! We came a long way. We hope this gives you a clearer picture of what the term hot vs cold actually means when it comes to Observables.


### PR DESCRIPTION
The share() operator can give trouble with streams that have an initial value. Added a note on how the shareReplay() can fix those problems.