### PR TITLE
Code correction

### DIFF
--- a/_posts/2017-11-20-custom-overlays-with-angulars-cdk.md
+++ b/_posts/2017-11-20-custom-overlays-with-angulars-cdk.md
@@ -94,7 +94,7 @@ export class FilePreviewOverlayService {
 
   open() {
     // Returns an OverlayRef (which is a PortalHost)
-    const overlayRef = overlay.create();
+    const overlayRef = this.overlay.create();
 
     // Create ComponentPortal that can be attached to a PortalHost
     const filePreviewPortal = new ComponentPortal(FilePreviewOverlayComponent);


### PR DESCRIPTION
Since `overlay` is in the constructor, I think it needs to be `this.overlay.create()`