### PR TITLE
It's just angular

### DIFF
--- a/categories-angular-2.html
+++ b/categories-angular-2.html
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Angular 2 articles by thoughtram
+title: Angular articles by thoughtram
 description: Find all of our high-quality Angular 2 articles that cover tips, tricks and best practices - always up to date!
 permalink: /categories/angular-2/
 ---
 
-<h2 class="thtrm-section-headline thtrm-section-headline--with-margin">Angular 2 articles</h2>
+<h2 class="thtrm-section-headline thtrm-section-headline--with-margin">Angular articles</h2>
 <ul class="thtrm-three-column-list thtrm-three-column-list--with-padding">
 {% for post in site.posts %}
   {% if post.tags contains 'angular2' %}


### PR DESCRIPTION
This is just a temporary fix, though.

The URL is still `angular-2` for Angular and `angular` for AngularJS. We can setup `angular-js` for AngularJS but then any links that people posted on the net to `angular` would lead to Angular (and not AngularJS as it is at the moment). `angular-2` can, of course, be redirected to `angular`.

There are also tags, but I can't see this displayed anywhere so it might not be an issue at all for visitors. Still something that could use fixing to not cause confusion while adding tags to posts, though.

But I'd like to hear input from maintainers first on this, as it could be a SEO/marketing issue.